### PR TITLE
Hotfix for image alt-text not rendering properly on mobile

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -218,8 +218,7 @@
         {%- render 'image', image: image, sizes: '50vw' -%}
       </div>
     {%- endif -%}
-              <!-- <img class="size-guide-img"src="https://plus.unsplash.com/premium_photo-1671461774955-7aab3ab41b90?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3
-wxMjA3fDB8MHxzZWFyY2h8MXx8c3ByZWFkc2hlZXR8ZW58MHx8MHx8fDA%3D" alt="Your image description"> -->
+            
     
             
 

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -208,7 +208,7 @@
             <div class="size-guide__drawer-inner js-drawer-inner">
               {%- assign image = current_variant.metafields.custom.size_guide.value | default: "" -%}
                 {% if image != "" %}
-                  <img src="{{ image }}" alt="Size Guide">
+                 <p>Size Guide</p>
                 {% else %}
                   <p>No size guide available</p>
                 {% endif %}
@@ -218,17 +218,13 @@
         {%- render 'image', image: image, sizes: '50vw' -%}
       </div>
     {%- endif -%}
-            
-    
-            
-
-              <button type="button" class="size-guide__drawer-close js-drawer-close">
-                Close
-              </button>
-            </div>
-          </details>
-        </size-guide-drawer>
-            
+          <button type="button" class="size-guide__drawer-close js-drawer-close">
+            Close
+          </button>
+        </div>
+      </details>
+    </size-guide-drawer>
+        
 
         </div>
       {%- endif -%}


### PR DESCRIPTION
- Removed the original image, that was used solely for alt-text, and refactored to simply text so that it works on mobile 
- Also removed commented out testing image